### PR TITLE
필터 정리

### DIFF
--- a/General/general.txt
+++ b/General/general.txt
@@ -14,23 +14,11 @@ www.inven.co.kr###adHomeTop
 sportsseoul.com###SS_slides > .slidesjs-container > .slidesjs-control
 news.donga.com###container > .article_title02 > .notice_banner > .notice_banner
 news.donga.com###sub_header > .sub_header_box > .bigtoon_banner > a[href^="http://bigtoon.donga.com"] > img[alt="무료만화"]
-||news.inews24.com/inc/right_file_banner_125.php?mains=News
-news.inews24.com###ma_w_1
-news.inews24.com###ma_w_2
-||news.inews24.com/inc/right_file_banner.php?mains=News
-news.inews24.com###ma_w_17 > table > tbody > tr > td
-news.inews24.com###ma_w_3
-news.inews24.com###ma_w_4
-news.inews24.com###AD_LIVE_AREA_21803080
-news.inews24.com###ma_w_7
-news.inews24.com###ma_w_5
-news.inews24.com###rcView_inews6
-news.inews24.com###ma_w_12
-news.inews24.com###content > .ma_w_12_13
-news.inews24.com###ma_w_11 > iframe
-news.inews24.com###ma_w_11
-news.inews24.com###ma_w_10 > iframe
-news.inews24.com###ma_w_10
+news.inews24.com##DIV[id^="ma_w_"]
+news.inews24.com##DIV[class^="ma_w_"]
+||news.inews24.com/inc/right_file_banner_125.php$subdocument
+||inews24.com/tools/adpresso/inc_middle_banner2nd2.php$subdocument
+news.inews24.com##DIV[style="float:right; width:200px; height:200px; margin-left:10px;  margin-bottom:10px;overflow:hidden;"]
 www.clien.net###content > .board_main > div:nth-of-type(4) > div
 www.clien.net###content > .board_main > div:nth-of-type(4)
 www.clien.net###content > .board_main > div:nth-of-type(4)


### PR DESCRIPTION
news.inews24.com###ma_w_?? 필터들은 news.inews24.com##DIV[id^="ma_w_"], news.inews24.com##DIV[class^="ma_w_"] 으로 정리 가능
기사 본문의 광고는 news.inews24.com##DIV[style="float:right; width:200px; height:200px; margin-left:10px;  margin-bottom:10px;overflow:hidden;"] 으로 제거 가능

||news.inews24.com/inc/right_file_banner_125.php$subdocument 으로 ||news.inews24.com/inc/right_file_banner_125.php?mains=News 처리 가능하며 나머지도 같은 이유로 제거 합니다.